### PR TITLE
fix twilioflex media creation contenttype param

### DIFF
--- a/services/tickets/twilioflex/client.go
+++ b/services/tickets/twilioflex/client.go
@@ -227,6 +227,13 @@ func (c *Client) CreateMedia(media *CreateMediaParams) (*Media, *httpx.Trace, er
 	filenameReader := bytes.NewReader([]byte(media.FileName))
 	io.Copy(filenamePart, filenameReader)
 
+	mediaContentTypePart, err := writer.CreateFormField("ContentType")
+	if err != nil {
+		return nil, nil, err
+	}
+	mediaContentTypeReader := bytes.NewReader([]byte(media.ContentType))
+	io.Copy(mediaContentTypePart, mediaContentTypeReader)
+
 	writer.Close()
 
 	req, err := httpx.NewRequest("POST", url, body, map[string]string{})

--- a/services/tickets/twilioflex/client_test.go
+++ b/services/tickets/twilioflex/client_test.go
@@ -391,6 +391,7 @@ func TestCreateMediaResource(t *testing.T) {
 	response, trace, err := client.CreateMedia(mediaContent)
 	assert.NoError(t, err)
 	assert.Equal(t, "00ac28a5d76a30d5c8ec4f3a73964887.jpg", response.Filename)
+	assert.Equal(t, "image/jpeg", response.ContentType)
 	assert.Equal(t, "HTTP/1.0 201 Created\r\nContent-Length: 788\r\n\r\n", string(trace.ResponseTrace))
 }
 

--- a/services/tickets/twilioflex/service.go
+++ b/services/tickets/twilioflex/service.go
@@ -124,10 +124,7 @@ func (s *service) Open(session flows.Session, topic *flows.Topic, body string, a
 		FlexFlowSid *string `json:"flex_flow_sid,omitempty"`
 	}{}
 
-	err = json.Unmarshal([]byte(body), &bodyStruct)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal body")
-	}
+	json.Unmarshal([]byte(body), &bodyStruct)
 
 	if bodyStruct.FlexFlowSid != nil {
 		flexChannelParams.FlexFlowSid = *bodyStruct.FlexFlowSid


### PR DESCRIPTION
we set the contenttype in the service forward, but it didn't catch in the client action, and it was still going without contentype, now with this fix it will correct this omission.