### PR TITLE
fix: fix problem in tickets last activity on field

### DIFF
--- a/core/runner/handlers/ticket_assignee_changed.go
+++ b/core/runner/handlers/ticket_assignee_changed.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/goflow/flows"
 	"github.com/nyaruka/goflow/flows/events"
 	"github.com/nyaruka/mailroom/core/models"
@@ -33,6 +34,7 @@ func handleTicketAssigneeChanged(ctx context.Context, rt *runtime.Runtime, oa *m
 
 	dbTicket := scene.DBContact.FindTicket(event.TicketUUID)
 	dbTicket.AssigneeID = assigneeID
+	dbTicket.LastActivityOn = dates.Now()
 
 	scene.AttachPreCommitHook(hooks.UpdateTickets, dbTicket)
 

--- a/web/ticket/testdata/change_assignee.json
+++ b/web/ticket/testdata/change_assignee.json
@@ -60,6 +60,10 @@
             {
                 "query": "SELECT count(*) FROM tickets_ticket WHERE assignee_id = 5",
                 "returns": 3
+            },
+            {
+                "query": "SELECT count(*) FROM tickets_ticket WHERE assignee_id = 5 AND last_activity_on > '2000-01-01'",
+                "returns": 3
             }
         ],
         "expected_history": [
@@ -145,6 +149,10 @@
         "db_assertions": [
             {
                 "query": "SELECT count(*) FROM tickets_ticket WHERE id = 30000 AND assignee_id IS NULL",
+                "returns": 1
+            },
+            {
+                "query": "SELECT count(*) FROM tickets_ticket WHERE id = 30000 AND last_activity_on > '2000-01-01'",
                 "returns": 1
             }
         ],

--- a/web/ticket/testdata/change_assignee.json
+++ b/web/ticket/testdata/change_assignee.json
@@ -40,9 +40,9 @@
                         }
                     },
                     {
-                        "uuid": "01969b47-0d53-76f8-bd38-d266ec8d3716",
+                        "uuid": "01969b47-113b-76f8-bd38-d266ec8d3716",
                         "type": "ticket_assignee_changed",
-                        "created_on": "2025-05-04T12:30:48.123456789Z",
+                        "created_on": "2025-05-04T12:30:49.123456789Z",
                         "_user": {
                             "uuid": "e29fdf9f-56ab-422a-b77d-e3ec26091a25",
                             "name": "Andy Admin"
@@ -91,7 +91,7 @@
             },
             {
                 "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
-                "SK": "evt#01969b47-0d53-76f8-bd38-d266ec8d3716",
+                "SK": "evt#01969b47-113b-76f8-bd38-d266ec8d3716",
                 "OrgID": 1,
                 "Data": {
                     "_user": {
@@ -102,7 +102,7 @@
                         "name": "Ann D'Agent",
                         "uuid": "27e44553-ab35-482b-a4d4-6f000ec611ab"
                     },
-                    "created_on": "2025-05-04T12:30:48.123456789Z",
+                    "created_on": "2025-05-04T12:30:49.123456789Z",
                     "ticket_uuid": "01992f54-5ab6-7498-a7f2-6aa246e45cfe",
                     "type": "ticket_assignee_changed"
                 }
@@ -129,9 +129,9 @@
             "events": {
                 "a393abc0-283d-4c9b-a1b3-641a035c34bf": [
                     {
-                        "uuid": "01969b47-190b-76f8-9c0b-2014ddc77094",
+                        "uuid": "01969b47-20db-76f8-9c0b-2014ddc77094",
                         "type": "ticket_assignee_changed",
-                        "created_on": "2025-05-04T12:30:51.123456789Z",
+                        "created_on": "2025-05-04T12:30:53.123456789Z",
                         "_user": {
                             "uuid": "e29fdf9f-56ab-422a-b77d-e3ec26091a25",
                             "name": "Andy Admin"
@@ -159,7 +159,7 @@
         "expected_history": [
             {
                 "PK": "con#a393abc0-283d-4c9b-a1b3-641a035c34bf",
-                "SK": "evt#01969b47-190b-76f8-9c0b-2014ddc77094",
+                "SK": "evt#01969b47-20db-76f8-9c0b-2014ddc77094",
                 "OrgID": 1,
                 "Data": {
                     "_user": {
@@ -167,7 +167,7 @@
                         "uuid": "e29fdf9f-56ab-422a-b77d-e3ec26091a25"
                     },
                     "assignee": null,
-                    "created_on": "2025-05-04T12:30:51.123456789Z",
+                    "created_on": "2025-05-04T12:30:53.123456789Z",
                     "previous": {
                         "name": "Ann D'Agent",
                         "uuid": "27e44553-ab35-482b-a4d4-6f000ec611ab"


### PR DESCRIPTION
## Problem

`handleTicketAssigneeChanged` was not updating `LastActivityOn` when processing assignee changes, unlike all the other ticket handlers (`ticket_topic_changed`, `ticket_note_added`, `ticket_closed`, `ticket_reopened`).

Combined with the fact that tickets reconstructed from the contact's JSON in `core/models/contact.go` come with `LastActivityOn = time.Time{}` (Go's zero value), the SQL `UPDATE tickets_ticket SET last_activity_on = r.last_activity_on, modified_on = NOW() ...` was writing `0001-01-01 00:00:00 UTC` to the database while `modified_on` correctly received `NOW()`.

## Production symptom

Tickets with:

- `last_activity_on = '0001-01-01 00:00:00+00'`
- `modified_on` updated normally (current date)
- `status = 'O'`, with or without `assignee_id` (if a ticket had an assignee that was later removed, the symptom persists because the handler has the same bug on both transitions)

In the tickets UI, this surfaces as `"2025 years ago"` in the ticket list, since the frontend uses `last_activity_on` to render the relative time.

We confirmed this in production: 58 tickets across 3 orgs (U-Report Jamaica, GE Kenya, BIG SIS) had `last_activity_on = '0001-01-01'`, with `modified_on` always recent. The split between t